### PR TITLE
simply interface of getting messaging object

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ defmodule Sample.Router do
 
   def message(msg) do
     message = FacebookMessenger.Response.parse(msg)
+      |> FacebookMessenger.Response.get_messaging
 
     case message.type do
       "postback" -> YourApplication.process_postback(message)

--- a/lib/models/facebook_messenger_response.ex
+++ b/lib/models/facebook_messenger_response.ex
@@ -27,6 +27,14 @@ defmodule FacebookMessenger.Response do
   end
 
   @doc """
+  Get shorter representation of message data
+  """
+  @spec get_messaging(FacebookMessenger.Response.t) :: FacebookMessenger.Messaging.t
+  def get_messaging(%{entry: entries}) do
+    entries |> hd |> Map.get(:messaging) |> hd
+  end
+
+  @doc """
   Return an list of message texts from a `FacebookMessenger.Response`
   """
   @spec message_texts(FacebookMessenger.Response) :: [String.t]

--- a/test/facebook_messenger_test.exs
+++ b/test/facebook_messenger_test.exs
@@ -39,11 +39,10 @@ defmodule FacebookMessenger.Message.Test do
       {:ok, json} = file |> Poison.decode
 
       res = FacebookMessenger.Response.parse(json)
-      messaging = res.entry |> hd |> Map.get(:messaging)
+      messaging = res |> FacebookMessenger.Response.get_messaging
 
-      postback = messaging |> hd |> Map.get(:postback)
-
-      assert postback.payload == "USER_DEFINED_PAYLOAD"
+      assert messaging.type == "postback"
+      assert messaging.postback.payload == "USER_DEFINED_PAYLOAD"
     end
 
   test "text message gets the message text from the response" do


### PR DESCRIPTION
Currently when message is parsed you will need manually traverse over entire response structure and get values properly. In most cases you don't need full structure so in this case the idea is to simply call ```get_messaging``` assuming that parsing was success.